### PR TITLE
fixing crash in cached package name retrieval

### DIFF
--- a/aosd/downloader/packages.py
+++ b/aosd/downloader/packages.py
@@ -27,7 +27,7 @@ class packages(object):
         package_cache_path = cacher.GetCacheFile('package_cache.plist');
         if os.path.exists(package_cache_path) == True:
             package_cache = plistlib.readPlist(package_cache_path);
-            release_packages = package_cache[str(release_type)];
+            release_packages = package_cache.get(str(release_type), None);
             if release_packages != None:
                 for package_name in release_packages:
                     packages.append(str(package_name));


### PR DESCRIPTION
Problem:
If package_cache.plist does not contain an entry for the specified type, subsequently attempting to specify a package will cause a KeyError exception to be thrown.

Steps to reproduce:  
- start with a package_cache.plist without an entry for 'mac' in the root dict
- run the following commands in the console:  
type mac  
package CF  

Fix:
Use get() to retrieve release package list (or return None if release type is not in the cache)