### PR TITLE
fixing capitalization issues leading to ImportError(s)

### DIFF
--- a/aosd/commandparse/CmdBuild.py
+++ b/aosd/commandparse/CmdBuild.py
@@ -2,7 +2,7 @@
 imports
 """
 from .RootCmd import RootCmd
-from ..downloader.Builds import Builds
+from ..downloader.builds import Builds
 
 class CmdBuild(RootCmd):
     """

--- a/aosd/commandparse/CmdDiff.py
+++ b/aosd/commandparse/CmdDiff.py
@@ -4,7 +4,7 @@ imports
 from .RootCmd import RootCmd
 from ..logging_helper import logging_helper
 from ..downloader.diff import diff
-from ..downloader.Builds import Builds
+from ..downloader.builds import Builds
 
 class CmdDiff(RootCmd):
     """

--- a/aosd/commandparse/CmdPackage.py
+++ b/aosd/commandparse/CmdPackage.py
@@ -2,7 +2,7 @@
 imports
 """
 from .RootCmd import RootCmd
-from ..downloader.Packages import Packages
+from ..downloader.packages import Packages
 
 class CmdPackage(RootCmd):
 

--- a/aosd/downloader/__init__.py
+++ b/aosd/downloader/__init__.py
@@ -1,3 +1,3 @@
 from .config import config
 from .releases import releases
-from .Packages import Packages
+from .packages import Packages

--- a/aosd/downloader/manager.py
+++ b/aosd/downloader/manager.py
@@ -17,7 +17,7 @@ import gzip
 import tarfile
 
 from .config import config
-from .Builds import Builds
+from .builds import Builds
 
 class manager(object):
 

--- a/aosd/flags.py
+++ b/aosd/flags.py
@@ -4,7 +4,7 @@ from .downloader.diff import diff
 from .downloader import releases
 from .downloader import config
 from .downloader.cacher import cacher
-from .downloader.Builds import Builds
+from .downloader.builds import Builds
 from .logging_helper import logging_helper
 
 def ParseFlags(args_dict):


### PR DESCRIPTION
Some of the module imports were not properly capitalized causing crashes
